### PR TITLE
fix when property no key

### DIFF
--- a/rules/form-getFieldDecorator-exclusive.js
+++ b/rules/form-getFieldDecorator-exclusive.js
@@ -12,7 +12,7 @@ module.exports = {
       }
       for (var i = 0; i < config.properties.length; ++i) {
         const property = config.properties[i];
-        if (property.key.name === 'exclusive') {
+        if (property.key && property.key.name === 'exclusive') {
           return true;
         }
       }


### PR DESCRIPTION
当getFieldDecorator的第二个参数由函数动态生成时, property.key === undefined，property.key.name会报错